### PR TITLE
The image is a child of position relative or absolute elements

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -206,7 +206,7 @@ if ( typeof Object.create !== 'function' ) {
 				//self.zoomContainer = $('<div/>').addClass('zoomContainer').css({"position":"relative", "height":self.nzHeight, "width":self.nzWidth});
 
 				self.zoomContainer = $('<div class="zoomContainer" style="position:absolute;left:'+self.nzOffset.left+'px;top:'+self.nzOffset.top+'px;height:'+self.nzHeight+'px;width:'+self.nzWidth+'px;"></div>');
-				self.$elem.after(self.zoomContainer);	
+				$('body').append(self.zoomContainer);	
 
 
 				//this will add overflow hidden and contrain the lens on lens mode       


### PR DESCRIPTION
...ithin an element that is position absolute. The js now makes the zoomContainer div a child of the body element. The reason for the fix is that the zoomContainer and the lens were offset relative to my image by the distance that my image was offset by the browser window. This fix is only for img tags that are children of elements that are position absolute or relative.
