### PR TITLE
Fix lens proportion calculation

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -189,7 +189,7 @@ if ( typeof Object.create !== 'function' ) {
 
 					// adjust images less than the window height
 
-					if(self.nzHeight < self.options.zoomWindowWidth/self.widthRatio){
+					if(self.nzHeight < self.options.zoomWindowHeight/self.heightRatio){
 						lensHeight = self.nzHeight;              
 					}
 					else{


### PR DESCRIPTION
The condition was incorrectly checking for the width of the zoom window instead of the height, causing the lens to be equal height with the non-zoomed image when the actual viewport was smaller
