### PR TITLE
round lens position to avoid border flickering

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -671,8 +671,8 @@ if ( typeof Object.create !== 'function' ) {
 					if(self.options.showLens) {
 						//		self.showHideLens("show");
 						//set background position of lens
-						self.lensLeftPos = String(self.mouseLeft - self.zoomLens.width() / 2);
-						self.lensTopPos = String(self.mouseTop - self.zoomLens.height() / 2);
+						self.lensLeftPos = String(Math.floor(self.mouseLeft - self.zoomLens.width() / 2));
+						self.lensTopPos = String(Math.floor(self.mouseTop - self.zoomLens.height() / 2));
 
 
 					}


### PR DESCRIPTION
when the ` / 2` calculating the zoom lens position gives a non-integer result, eg `23.5px` the 1px border of the lens start to flicker as you move the lens (at bottom or right edges).
this `Math.floor` fixes that effect.