### PR TITLE
Replace deprecated mousewheel event with wheel event.

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -490,7 +490,7 @@ if ( typeof Object.create !== 'function' ) {
 				if(self.options.scrollZoom){
 
 
-					self.zoomContainer.add(self.$elem).bind('mousewheel DOMMouseScroll MozMousePixelScroll', function(e){
+					self.zoomContainer.add(self.$elem).bind('wheel DOMMouseScroll MozMousePixelScroll', function(e){
 
 
 //						in IE there is issue with firing of mouseleave - So check whether still scrolling
@@ -502,7 +502,7 @@ if ( typeof Object.create !== 'function' ) {
 							//do something
 						}, 250));
 
-						var theEvent = e.originalEvent.wheelDelta || e.originalEvent.detail*-1
+						var theEvent = e.originalEvent.deltaY || e.originalEvent.detail*-1
 
 
 						//this.scrollTop += ( delta < 0 ? 1 : -1 ) * 30;


### PR DESCRIPTION
Remove support for deprecated mousewheel event and replace with wheel event.

See: https://developer.mozilla.org/en-US/docs/Web/Events/mousewheel
