### PR TITLE
Added callback function 'onDestroy'

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -448,6 +448,7 @@ if ( typeof Object.create !== 'function' ) {
 				}).mouseleave(function(){
 					if(!self.scrollLock){
 						self.setElements("hide");
+						self.options.onDestroy(self.$elem);
 					}
 				});
 				//end ove image
@@ -1769,6 +1770,7 @@ if ( typeof Object.create !== 'function' ) {
 			cursor:"default", // user should set to what they want the cursor as, if they have set a click function
 			responsive:true,
 			onComplete: $.noop,
+			onDestroy: function() {},
 			onZoomedImageLoaded: function() {},
 			onImageSwap: $.noop,
 			onImageSwapComplete: $.noop


### PR DESCRIPTION
Added callback function 'onDestroy'. It is useful to destroy/hide 'zoomContainer' div when working with single page application (e.g; AngularJS application)

**Example:**

```javascript
$('.imgZoom').elevateZoom({
     'onDestroy': function (e) {
      $('.zoomContainer').css('left', '-9999px');
     }
    });
```