### PR TITLE
* Fixed broken CSS

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -172,7 +172,7 @@ if ( typeof Object.create !== 'function' ) {
 						+ "margin-top: " + String(borderWidth) + ";"         
 						+ "background-position: 0px 0px;"
 						+ "width: " + String(self.nzWidth) + "px;"
-						+ "height: " + String(self.nzHeight)
+						+ "height: " + String(self.nzHeight) + "px;"
 						+ "px;float: left;"
 						+ "display: none;"
 						+ "cursor:"+(self.options.cursor)+";"
@@ -659,7 +659,7 @@ if ( typeof Object.create !== 'function' ) {
 				}
 
 				// if the mouse position of the slider is one of the outerbounds, then hide  window and lens
-				if (self.mouseLeft <= 0 || self.mouseTop < 0 || self.mouseLeft > self.nzWidth || self.mouseTop > self.nzHeight ) {				          
+				if (self.mouseLeft < 0 || self.mouseTop < 0 || self.mouseLeft > self.nzWidth || self.mouseTop > self.nzHeight ) {				          
 					self.setElements("hide");
 					return;
 				}
@@ -774,7 +774,13 @@ if ( typeof Object.create !== 'function' ) {
 				if(change == "hide"){
 					if(self.isWindowActive){
 						if(self.options.zoomWindowFadeOut){
-							self.zoomWindow.stop(true, true).fadeOut(self.options.zoomWindowFadeOut);
+							self.zoomWindow.stop(true, true).fadeOut(self.options.zoomWindowFadeOut, function () {
+								if (self.loop) {
+									//stop moving the zoom window when zoom window is faded out
+									clearInterval(self.loop);
+									self.loop = false;
+								}
+							});
 						}
 						else{self.zoomWindow.hide();}
 						self.isWindowActive = false;        
@@ -995,13 +1001,15 @@ if ( typeof Object.create !== 'function' ) {
 					}
 					// adjust images less than the window height
 
-					if(self.largeHeight < self.options.zoomWindowHeight){
+					if (self.options.zoomType == "window") {
+						if (self.largeHeight < self.options.zoomWindowHeight) {
 
-						self.windowTopPos = 0;
+							self.windowTopPos = 0;
+						}
+						if (self.largeWidth < self.options.zoomWindowWidth) {
+							self.windowLeftPos = 0;
+						}
 					}
-					if(self.largeWidth < self.options.zoomWindowWidth){
-						self.windowLeftPos = 0;
-					}       
 
 					//set the zoomwindow background position
 					if (self.options.easing){
@@ -1070,6 +1078,12 @@ if ( typeof Object.create !== 'function' ) {
 									self.scrollingLock = false;
 									self.loop = false;
 
+								}
+								else if (Math.round(Math.abs(self.xp - self.windowLeftPos) + Math.abs(self.yp - self.windowTopPos)) < 1) {
+									//stops micro movements
+									clearInterval(self.loop);
+									self.zoomWindow.css({ backgroundPosition: self.windowLeftPos + 'px ' + self.windowTopPos + 'px' });
+									self.loop = false;
 								}
 								else{
 									if(self.changeBgSize){    
@@ -1170,7 +1184,6 @@ if ( typeof Object.create !== 'function' ) {
 					self.largeWidth = newImg.width;
 					self.largeHeight = newImg.height;
 					self.zoomImage = largeimage;
-					self.zoomWindow.css({ "background-size": self.largeWidth + 'px ' + self.largeHeight + 'px' });
 					self.zoomWindow.css({ "background-size": self.largeWidth + 'px ' + self.largeHeight + 'px' });
 
 


### PR DESCRIPTION
* Fixed mosu position outer bounds check, caused the zoomed image to dissapear without fading when hovering on pixel x:1

* Stop re-positioning the zoomed image when image has faded-out

* Fixed conflict with self.options.zoomWindowHeight/Width and zoomType=inner. Plugin didn't work for small images because of this

* Stop micro movements after easing