### PR TITLE
fix MouseWheel event management, fixes #132

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -503,7 +503,7 @@ if ( typeof Object.create !== 'function' ) {
 							//do something
 						}, 250));
 
-						var theEvent = e.originalEvent.wheelDelta || e.originalEvent.detail*-1
+						var theEvent = -e.originalEvent.deltaY || 0;
 
 
 						//this.scrollTop += ( delta < 0 ? 1 : -1 ) * 30;

--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -503,7 +503,7 @@ if ( typeof Object.create !== 'function' ) {
 							//do something
 						}, 250));
 
-						var theEvent = -e.originalEvent.deltaY || 0;
+						var theEvent = e.originalEvent.deltaY || e.originalEvent.detail * -1;
 
 
 						//this.scrollTop += ( delta < 0 ? 1 : -1 ) * 30;


### PR DESCRIPTION
i've change the MouseWheel management for scrollZoom issue following this specs -> 
https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent

now zoom in and zoom out are working. (tested on IE11, Edge, Firefox, Chrome)

cheers.
